### PR TITLE
Bump FormAPI version to ^2.1.0

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -8,5 +8,5 @@ projects:
     icon: icon.png
     libs:
     - src: jojoe77777/FormAPI/libFormAPI
-      version: ^1.3.0
+      version: ^2.1.0
 ...


### PR DESCRIPTION
^1.3.0 does not support PM4. 

*This pull request is untested.*